### PR TITLE
Avoids truncated webservices log

### DIFF
--- a/src/log/LogMiddlewareFactory.php
+++ b/src/log/LogMiddlewareFactory.php
@@ -11,7 +11,7 @@ use Monolog\Formatter\LineFormatter;
 final class LogMiddlewareFactory
 {
 
-    public static function get(string $wsFileName, string $current_user): LogMiddleware
+    public static function get(string $wsFileName, string $current_user, int $truncateSize = 3500): LogMiddleware
     {
         $logger = new Logger('GCA-webservices');
         $stream = new StreamHandler(
@@ -21,7 +21,7 @@ final class LogMiddlewareFactory
         $format = "[%datetime%] [{$current_user}] %message% %context%\n";
         $stream->setFormatter(new LineFormatter($format));
         $logger->pushHandler($stream);
-        $handler = new MultiRecordArrayHandler();
+        $handler = new MultiRecordArrayHandler(null, $truncateSize);
         $middleware = new LogMiddleware($logger, $handler);
 
         return $middleware;

--- a/src/webservices/config/ConfigFactory.php
+++ b/src/webservices/config/ConfigFactory.php
@@ -15,10 +15,32 @@ final class ConfigFactory
         self::$webservice = $webservice;
         $config  = self::getWSConfig($webservice);
         $wsFileName = self::getWSFileName();
-        $handler = MiddlewareFactory::get((int) $config['cache_lifetime'], $wsFileName, $current_user);
+        $truncateSize = self::getWSTruncateSize();
+        $handler = MiddlewareFactory::get(
+            (int) $config['cache_lifetime'],
+            $wsFileName,
+            $current_user,
+            $truncateSize
+        );
         $config['handler'] = $handler;
 
         return new Config(self::$webservice, $config);
+    }
+
+    /**
+     * Log line will truncate if it has a number of characters higher than the
+     * number returned by this function. If this number is not set in
+     * config_override.php, it will default to 3500.
+     */
+    private static function getWSTruncateSize() : int
+    {
+        $default_value = 3500;
+        $size = \SugarConfig::getInstace()->get('ws_logger_truncateSize');
+        if (empty($size)) {
+            return $default_value;
+        } else {
+            return (int) $size;
+        }
     }
 
     private static function getWSConfig(string $webservice) :array

--- a/src/webservices/middleware/MiddlewareFactory.php
+++ b/src/webservices/middleware/MiddlewareFactory.php
@@ -8,11 +8,15 @@ use Gcoop\Log\LogMiddlewareFactory;
 
 final class MiddlewareFactory
 {
-    public static function get(int $cacheLifeTime, string $wsFileName, string $current_user)
-    {
+    public static function get(
+        int $cacheLifeTime,
+        string $wsFileName,
+        string $current_user,
+        int $truncateSize = 3500
+    ) {
         $stack = HandlerStack::create();
         $cache = CacheMiddlewareFactory::get($cacheLifeTime);
-        $log   = LogMiddlewareFactory::get($wsFileName, $current_user);
+        $log   = LogMiddlewareFactory::get($wsFileName, $current_user, $truncateSize);
 
         $stack->push($cache, 'greedy-cache');
         $stack->push($log, 'webservices_logger');


### PR DESCRIPTION
Avoids webservices log to be truncated, unless its length is beyond a certain number, defined on config.